### PR TITLE
Fix authentication-token-webhook-config-file docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,12 @@ The Kubernetes API integrates with Heptio Authenticator for AWS using a [token a
 When you run `heptio-authenticator-aws server`, it will generate a webhook configuration file and save it onto the host filesystem.
 You'll need to add a single additional flag to your API server configuration:
 ```
---authentication-token-webhook-config-file=/etc/kubernetes/heptio-authenticator-aws.kubeconfig
+--authentication-token-webhook-config-file=/etc/kubernetes/heptio-authenticator-aws/kubeconfig.yaml
 ```
 
 On many clusters, the API server runs as a static pod.
 You can add the flag to `/etc/kubernetes/manifests/kube-apiserver.yaml`.
+Make sure the host directory `/etc/kubernetes/heptio-authenticator-aws/` is mounted into your API server pod.
 You may also need to restart the kubelet daemon on your master node to pick up the updated static pod definition:
 ```
 systemctl restart kubelet.service

--- a/cmd/heptio-authenticator-aws/server.go
+++ b/cmd/heptio-authenticator-aws/server.go
@@ -47,7 +47,7 @@ func init() {
 	viper.SetDefault("server.port", DefaultPort)
 
 	serverCmd.Flags().String("generate-kubeconfig",
-		"/etc/kubernetes/heptio-authenticator-aws.kubeconfig",
+		"/etc/kubernetes/heptio-authenticator-aws/kubeconfig.yaml",
 		"Output `path` where a generated webhook kubeconfig (for `--authentication-token-webhook-config-file`) will be stored (should be a hostPath mount).")
 	viper.BindPFlag("server.generateKubeconfig", serverCmd.Flags().Lookup("generate-kubeconfig"))
 


### PR DESCRIPTION
This was slightly wrong, and needed an extra note to work on 1.8.3 kubeadm clusters.
Previously, the entire `/etc/kubernetes` was mounted into the static API server pod,
but now only the `/etc/kubernetes/pki` and `/etc/ssl/certs` host directories are mounted.