### PR TITLE
add build container for simple binary build

### DIFF
--- a/buid-heptio-authenticator-aws.sh
+++ b/buid-heptio-authenticator-aws.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# create output folder for binary
+mkdir -p build-output
+
+# build in dockcer container and copy to build output dir
+docker run -v $(pwd)/build-output:/project golang:1.8.0-alpine sh -c "apk -Uuv add curl git && go get -u -v github.com/heptio/authenticator/cmd/heptio-authenticator-aws && cp /go/bin/heptio-authenticator-aws /project"


### PR DESCRIPTION
I added a simple script to easy build the heptio binary. It's useful if you don't want to wast you laptop. In addition, it prevents versioning conflicts with existing developments.