### PR TITLE
Add tests target to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,21 @@
 default: build
 
 CMD_IMPORT ?= github.com/heptio/authenticator/cmd/heptio-authenticator-aws
+GITHUB_REPO ?= github.com/heptio/authenticator
 REPO ?= gcr.io/heptio-images/authenticator
 VERSION ?= v0.1.0
 
-.PHONY: build push build-container
+.PHONY: test build push build-container
 
-build: build-container heptio-authenticator-aws-osx
+build: test build-container heptio-authenticator-aws-osx
 
-heptio-authenticator-aws-osx:
+test:
+	go test -v -cover -race $(GITHUB_REPO)/...
+
+heptio-authenticator-aws-osx: test
 	GOOS=darwin GOARCH=amd64 go build -o heptio-authenticator-aws-osx $(CMD_IMPORT)
 
-build-container: ca-certificates.crt
+build-container: ca-certificates.crt test
 	GOOS=linux GOARCH=amd64 go build -o heptio-authenticator-aws $(CMD_IMPORT)
 	docker build . -t $(REPO):$(VERSION)
 


### PR DESCRIPTION
Tests are not currently run as part of the make.

Should be noted that -race takes the test time from ~0.1 seconds to ~3 seconds.  I am open to removing it if we feel running in all cases is too long and we can make a release target that runs it.

Signed-off-by: Matt Landis <matlan@amazon.com>