### PR TITLE
Canonicalize ARNs in the look up map.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -15,7 +15,7 @@
 
 [[projects]]
   name = "github.com/aws/aws-sdk-go"
-  packages = ["aws","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/credentials/stscreds","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/session","aws/signer/v4","internal/shareddefaults","private/protocol","private/protocol/query","private/protocol/query/queryutil","private/protocol/rest","private/protocol/xml/xmlutil","service/sts"]
+  packages = ["aws","aws/arn","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/credentials/stscreds","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/session","aws/signer/v4","internal/shareddefaults","private/protocol","private/protocol/query","private/protocol/query/queryutil","private/protocol/rest","private/protocol/xml/xmlutil","service/sts"]
   revision = "885962fbd7bf49bf62db54f63fb89f75611677cf"
   version = "v1.12.8"
 
@@ -261,6 +261,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "dbde8ad53469bdf6f2378f271937b4d09af589b8b574608616cac15a61fb5611"
+  inputs-digest = "526ede96d820faad72b528a225e12af05cc05acf4278793912ee516b7b873266"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/arn/arn.go
+++ b/pkg/arn/arn.go
@@ -1,0 +1,68 @@
+package arn
+
+import (
+	"fmt"
+	"strings"
+
+	awsarn "github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+)
+
+// Canonicalize validates IAM resources are appropriate for the authenticator
+// and converts STS assumed roles into the IAM role resource.
+//
+// Supported IAM resources are:
+//   * AWS account: arn:aws:iam::123456789012:root
+//   * IAM user: arn:aws:iam::123456789012:user/Bob
+//   * IAM role: arn:aws:iam::123456789012:role/S3Access
+//   * IAM Assumed role: arn:aws:sts::123456789012:assumed-role/Accounting-Role/Mary (converted to IAM role)
+//   * Federated user: arn:aws:sts::123456789012:federated-user/Bob
+func Canonicalize(arn string) (string, error) {
+	parsed, err := awsarn.Parse(arn)
+	if err != nil {
+		return "", fmt.Errorf("arn '%s' is invalid: '%v'", arn, err)
+	}
+
+	if err := checkPartition(parsed.Partition); err != nil {
+		return "", fmt.Errorf("arn '%s' does not have a recognized partition", arn)
+	}
+
+	parts := strings.Split(parsed.Resource, "/")
+	resource := parts[0]
+
+	switch parsed.Service {
+	case "sts":
+		switch resource {
+		case "federated-user":
+			return arn, nil
+		case "assumed-role":
+			if len(parts) < 2 {
+				return "", fmt.Errorf("assumed-role arn '%s' does not have a role", arn)
+			}
+			role := parts[1]
+			return fmt.Sprintf("arn:%s:iam::%s:role/%s", parsed.Partition, parsed.AccountID, role), nil
+		default:
+			return "", fmt.Errorf("unrecognized resource %s for service sts", parsed.Resource)
+		}
+	case "iam":
+		switch resource {
+		case "role", "user", "root":
+			return arn, nil
+		default:
+			return "", fmt.Errorf("unrecognized resource %s for service iam", parsed.Resource)
+		}
+	}
+
+	return "", fmt.Errorf("service %s in arn %s is not a valid service for identities", parsed.Service, arn)
+}
+
+func checkPartition(partition string) error {
+	switch partition {
+	case endpoints.AwsPartitionID:
+	case endpoints.AwsCnPartitionID:
+	case endpoints.AwsUsGovPartitionID:
+	default:
+		return fmt.Errorf("partion %s is not recognized", partition)
+	}
+	return nil
+}

--- a/pkg/arn/arn_test.go
+++ b/pkg/arn/arn_test.go
@@ -1,0 +1,32 @@
+package arn
+
+import (
+	"fmt"
+	"testing"
+)
+
+var arnTests = []struct {
+	arn      string // input arn
+	expected string // canonacalized arn
+	err      error  // expected error value
+}{
+	{"NOT AN ARN", "", fmt.Errorf("Not an arn")},
+	{"arn:aws:iam::123456789012:user/Alice", "arn:aws:iam::123456789012:user/Alice", nil},
+	{"arn:aws:iam::123456789012:role/Users", "arn:aws:iam::123456789012:role/Users", nil},
+	{"arn:aws:sts::123456789012:assumed-role/Admin/Session", "arn:aws:iam::123456789012:role/Admin", nil},
+	{"arn:aws:sts::123456789012:federated-user/Bob", "arn:aws:sts::123456789012:federated-user/Bob", nil},
+	{"arn:aws:iam::123456789012:root", "arn:aws:iam::123456789012:root", nil},
+}
+
+func TestUserARN(t *testing.T) {
+	for _, tc := range arnTests {
+		actual, err := Canonicalize(tc.arn)
+		if err != nil && tc.err == nil || err == nil && tc.err != nil {
+			t.Errorf("Canoncialize(%s) expected err: %v, actual err: %v", tc.arn, tc.err, err)
+			continue
+		}
+		if actual != tc.expected {
+			t.Errorf("Canonicalize(%s) expected: %s, actual: %s", tc.arn, tc.expected, actual)
+		}
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/heptio/authenticator/pkg/arn"
 	"github.com/heptio/authenticator/pkg/config"
 	"github.com/heptio/authenticator/pkg/token"
 
@@ -146,10 +147,20 @@ func (c *Server) getHandler() *handler {
 		metrics:          createMetrics(),
 	}
 	for _, m := range c.RoleMappings {
-		h.lowercaseRoleMap[strings.ToLower(m.RoleARN)] = m
+		canonicalizedARN, err := arn.Canonicalize(strings.ToLower(m.RoleARN))
+		if err != nil {
+			logrus.Errorf("Error canonicalizing ARN: %v", err)
+			continue
+		}
+		h.lowercaseRoleMap[canonicalizedARN] = m
 	}
 	for _, m := range c.UserMappings {
-		h.lowercaseUserMap[strings.ToLower(m.UserARN)] = m
+		canonicalizedARN, err := arn.Canonicalize(strings.ToLower(m.UserARN))
+		if err != nil {
+			logrus.Errorf("Error canonicalizing ARN: %v", err)
+			continue
+		}
+		h.lowercaseUserMap[canonicalizedARN] = m
 	}
 
 	for _, m := range c.AutoMappedAWSAccounts {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -96,7 +96,7 @@ func validateMetrics(t *testing.T, opts validateOpts) {
 				}
 				label := metric.Label[0]
 				if *label.Name != "result" {
-					t.Fatalf("Expected label to have name 'result' was %s", label.Name)
+					t.Fatalf("Expected label to have name 'result' was %s", *label.Name)
 				}
 				switch *label.Value {
 				case metricSuccess:

--- a/pkg/token/token_test.go
+++ b/pkg/token/token_test.go
@@ -141,7 +141,7 @@ func TestVerifyUnmarshalJSONError(t *testing.T) {
 
 func TestVerifyInvalidCanonicalARNError(t *testing.T) {
 	_, err := newVerifier(200, jsonResponse("arn", "1000", "userid"), nil).Verify(validToken)
-	errorContains(t, err, "malformed ARN")
+	errorContains(t, err, "arn 'arn' is invalid:")
 	assertSTSError(t, err)
 }
 


### PR DESCRIPTION
The ARNs from the token being validated are canonicalized before lookup.
This can cause a mismatch between what is sent by the client and what
has been configured in the mapping.  This canonicalizes the map as well.

This addresses issues #47 and #46 
