### PR TITLE
Fix build to not produce incomplete binaries

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,7 +3,7 @@ project_name: authenticator
 
 builds:
   - binary: heptio-authenticator-aws
-    main: ./cmd/heptio-authenticator-aws/root.go
+    main: ./cmd/heptio-authenticator-aws/
     goos:
       - darwin
       - linux


### PR DESCRIPTION
Resolves #48

This is manually verified to work by running:

```console
$ dist/darwin_amd64/heptio-authenticator-aws init --cluster-id foo
INFO[2018-03-19T12:09:59+09:00] generated a new private key and certificate   certBytes=811 keyBytes=1192
INFO[2018-03-19T12:09:59+09:00] saving new key and certificate                certPath=cert.pem keyPath=key.pem
INFO[2018-03-19T12:09:59+09:00] loaded existing keypair                       certPath=cert.pem keyPath=key.pem
INFO[2018-03-19T12:09:59+09:00] writing webhook kubeconfig file               kubeconfigPath=heptio-authenticator-aws.kubeconfig
INFO[2018-03-19T12:09:59+09:00] copy cert.pem to /var/heptio-authenticator-aws/cert.pem on kubernetes master node(s)
INFO[2018-03-19T12:09:59+09:00] copy key.pem to /var/heptio-authenticator-aws/key.pem on kubernetes master node(s)
INFO[2018-03-19T12:09:59+09:00] copy heptio-authenticator-aws.kubeconfig to /etc/kubernetes/heptio-authenticator-aws/kubeconfig.yaml on kubernetes master node(s)
INFO[2018-03-19T12:09:59+09:00] configure your apiserver with `--authentication-token-webhook-config-file=/etc/kubernetes/heptio-authenticator-aws/kubeconfig.yaml` to enable authentication with heptio-authenticator-aws
```
