### PR TITLE
Add a NodeMapping that automatically maps a role to the name used by kubelet

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -15,7 +15,34 @@
 
 [[projects]]
   name = "github.com/aws/aws-sdk-go"
-  packages = ["aws","aws/arn","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/credentials/stscreds","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/session","aws/signer/v4","internal/shareddefaults","private/protocol","private/protocol/query","private/protocol/query/queryutil","private/protocol/rest","private/protocol/xml/xmlutil","service/sts"]
+  packages = [
+    "aws",
+    "aws/arn",
+    "aws/awserr",
+    "aws/awsutil",
+    "aws/client",
+    "aws/client/metadata",
+    "aws/corehandlers",
+    "aws/credentials",
+    "aws/credentials/ec2rolecreds",
+    "aws/credentials/endpointcreds",
+    "aws/credentials/stscreds",
+    "aws/defaults",
+    "aws/ec2metadata",
+    "aws/endpoints",
+    "aws/request",
+    "aws/session",
+    "aws/signer/v4",
+    "internal/shareddefaults",
+    "private/protocol",
+    "private/protocol/ec2query",
+    "private/protocol/query",
+    "private/protocol/query/queryutil",
+    "private/protocol/rest",
+    "private/protocol/xml/xmlutil",
+    "service/ec2",
+    "service/sts"
+  ]
   revision = "885962fbd7bf49bf62db54f63fb89f75611677cf"
   version = "v1.12.8"
 
@@ -27,7 +54,10 @@
 
 [[projects]]
   name = "github.com/emicklei/go-restful"
-  packages = [".","log"]
+  packages = [
+    ".",
+    "log"
+  ]
   revision = "5741799b275a3c4a5a9623a993576d7545cf7b5c"
   version = "v2.4.0"
 
@@ -69,7 +99,10 @@
 
 [[projects]]
   name = "github.com/gogo/protobuf"
-  packages = ["proto","sortkeys"]
+  packages = [
+    "proto",
+    "sortkeys"
+  ]
   revision = "342cbe0a04158f6dcb03ca0079991a51a4248c02"
   version = "v0.5"
 
@@ -94,7 +127,17 @@
 [[projects]]
   branch = "master"
   name = "github.com/hashicorp/hcl"
-  packages = [".","hcl/ast","hcl/parser","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
+  packages = [
+    ".",
+    "hcl/ast",
+    "hcl/parser",
+    "hcl/scanner",
+    "hcl/strconv",
+    "hcl/token",
+    "json/parser",
+    "json/scanner",
+    "json/token"
+  ]
   revision = "42e33e2d55a0ff1d6263f738896ea8c13571a8d0"
 
 [[projects]]
@@ -117,7 +160,11 @@
 [[projects]]
   branch = "master"
   name = "github.com/mailru/easyjson"
-  packages = ["buffer","jlexer","jwriter"]
+  packages = [
+    "buffer",
+    "jlexer",
+    "jwriter"
+  ]
   revision = "2a92e673c9a6302dd05c3a691ae1f24aef46457d"
 
 [[projects]]
@@ -140,7 +187,10 @@
 
 [[projects]]
   name = "github.com/prometheus/client_golang"
-  packages = ["prometheus","prometheus/promhttp"]
+  packages = [
+    "prometheus",
+    "prometheus/promhttp"
+  ]
   revision = "967789050ba94deca04a5e84cce8ad472ce313c1"
   version = "v0.9.0-pre1"
 
@@ -153,13 +203,20 @@
 [[projects]]
   branch = "master"
   name = "github.com/prometheus/common"
-  packages = ["expfmt","internal/bitbucket.org/ww/goautoneg","model"]
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model"
+  ]
   revision = "2e54d0b93cba2fd133edc32211dcc32c06ef72ca"
 
 [[projects]]
   branch = "master"
   name = "github.com/prometheus/procfs"
-  packages = [".","xfs"]
+  packages = [
+    ".",
+    "xfs"
+  ]
   revision = "b15cd069a83443be3154b719d0cc9fe8117f09fb"
 
 [[projects]]
@@ -171,7 +228,10 @@
 [[projects]]
   branch = "master"
   name = "github.com/spf13/afero"
-  packages = [".","mem"]
+  packages = [
+    ".",
+    "mem"
+  ]
   revision = "e67d870304c4bca21331b02f414f970df13aa694"
 
 [[projects]]
@@ -213,19 +273,43 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["http2","http2/hpack","idna","lex/httplex"]
+  packages = [
+    "http2",
+    "http2/hpack",
+    "idna",
+    "lex/httplex"
+  ]
   revision = "a04bdaca5b32abe1c069418fb7088ae607de5bd0"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = ["unix","windows"]
+  packages = [
+    "unix",
+    "windows"
+  ]
   revision = "ebfc5b4631820b793c9010c87fd8fef0f39eb082"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/text"
-  packages = ["collate","collate/build","internal/colltab","internal/gen","internal/tag","internal/triegen","internal/ucd","language","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable","width"]
+  packages = [
+    "collate",
+    "collate/build",
+    "internal/colltab",
+    "internal/gen",
+    "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
+    "language",
+    "secure/bidirule",
+    "transform",
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable",
+    "width"
+  ]
   revision = "825fc78a2fd6fa0a5447e300189e3219e05e1f25"
 
 [[projects]]
@@ -249,7 +333,28 @@
 [[projects]]
   branch = "master"
   name = "k8s.io/apimachinery"
-  packages = ["pkg/api/resource","pkg/apis/meta/v1","pkg/conversion","pkg/conversion/queryparams","pkg/fields","pkg/labels","pkg/runtime","pkg/runtime/schema","pkg/selection","pkg/types","pkg/util/errors","pkg/util/intstr","pkg/util/net","pkg/util/runtime","pkg/util/sets","pkg/util/validation","pkg/util/validation/field","pkg/util/wait","pkg/watch","third_party/forked/golang/reflect"]
+  packages = [
+    "pkg/api/resource",
+    "pkg/apis/meta/v1",
+    "pkg/conversion",
+    "pkg/conversion/queryparams",
+    "pkg/fields",
+    "pkg/labels",
+    "pkg/runtime",
+    "pkg/runtime/schema",
+    "pkg/selection",
+    "pkg/types",
+    "pkg/util/errors",
+    "pkg/util/intstr",
+    "pkg/util/net",
+    "pkg/util/runtime",
+    "pkg/util/sets",
+    "pkg/util/validation",
+    "pkg/util/validation/field",
+    "pkg/util/wait",
+    "pkg/watch",
+    "third_party/forked/golang/reflect"
+  ]
   revision = "3b05bbfa0a45413bfa184edbf9af617e277962fb"
 
 [[projects]]
@@ -261,6 +366,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "526ede96d820faad72b528a225e12af05cc05acf4278793912ee516b7b873266"
+  inputs-digest = "6aef6e70631dea080fa7865b5cb7a6dab6d52f42219faec6f4fcefb1aeb183b8"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -219,4 +219,17 @@ server:
   mapAccounts:
   - "012345678901"
   - "456789012345"
+
+  # map nodes that should conform to the username "system:node:<private-DNS>".  This
+  # requires the authenticator to query the EC2 API in order to discover the private
+  # DNS of the EC2 instance originating the authentication request.  Optionally, you
+  # may specify a role that should be assumed before querying the EC2 API with the
+  # top level key "defaultEC2DescribeInstancesRoleARN"
+  defaultEC2DescribeInstancesRoleARN: arn:aws:iam::000000000000:role/DescribeInstancesRole
+  mapNodes:
+  - roleARN: arn:aws:iam::000000000000:role/KubernetesNode
+    groups:
+    - system:nodes
+    - system:bootstrappers
+
 ```

--- a/cmd/heptio-authenticator-aws/root.go
+++ b/cmd/heptio-authenticator-aws/root.go
@@ -75,17 +75,21 @@ func initConfig() {
 
 func getConfig() (config.Config, error) {
 	config := config.Config{
-		ClusterID:              viper.GetString("clusterID"),
-		LocalhostPort:          viper.GetInt("server.port"),
-		GenerateKubeconfigPath: viper.GetString("server.generateKubeconfig"),
-		KubeconfigPregenerated: viper.GetBool("server.kubeconfigPregenerated"),
-		StateDir:               viper.GetString("server.stateDir"),
+		ClusterID:                          viper.GetString("clusterID"),
+		DefaultEC2DescribeInstancesRoleARN: viper.GetString("defaultEC2DescribeInstancesRoleARN"),
+		LocalhostPort:                      viper.GetInt("server.port"),
+		GenerateKubeconfigPath:             viper.GetString("server.generateKubeconfig"),
+		KubeconfigPregenerated:             viper.GetBool("server.kubeconfigPregenerated"),
+		StateDir:                           viper.GetString("server.stateDir"),
 	}
 	if err := viper.UnmarshalKey("server.mapRoles", &config.RoleMappings); err != nil {
 		return config, fmt.Errorf("invalid server role mappings: %v", err)
 	}
 	if err := viper.UnmarshalKey("server.mapUsers", &config.UserMappings); err != nil {
 		logrus.WithError(err).Fatal("invalid server user mappings")
+	}
+	if err := viper.UnmarshalKey("server.mapNodes", &config.NodeMappings); err != nil {
+		logrus.WithError(err).Fatal("invalid server node mappings")
 	}
 	if err := viper.UnmarshalKey("server.mapAccounts", &config.AutoMappedAWSAccounts); err != nil {
 		logrus.WithError(err).Fatal("invalid server account mappings")

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -29,4 +29,7 @@ const (
 
 	// certLifetime is the lifetime of the CA certificate (100 years)
 	certLifetime = time.Hour * 24 * 365 * 100
+
+	// nodeNamePrefix is the username prefix that the apiserver expects of kubelet
+	NodeNamePrefix = "system:node:"
 )

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -56,6 +56,17 @@ type UserMapping struct {
 	Groups []string
 }
 
+// NodeMapping is a mapping of an AWS Role ARN that is used by a Kubernetes node
+// to a generated Username that matches the string "system:node:NodeName"
+// where NodeName is the private DNS of the calling EC2 instance.
+type NodeMapping struct {
+	// RoleARN is the AWS Resource Name of the EC2 Instance Role. (e.g., "arn:aws:iam::000000000000:role/Foo").
+	RoleARN string
+
+	// Groups is a list of Kubernetes groups this role will authenticate as (e.g., `system:nodes`)
+	Groups []string
+}
+
 // Config specifies the configuration for a heptio-authenticator-aws server
 type Config struct {
 	// ClusterID is a unique-per-cluster identifier for your
@@ -89,7 +100,17 @@ type Config struct {
 	// Kubernetes username + groups.
 	UserMappings []UserMapping
 
+	// NodeMappings is a list of mappings from AWS IAM Role to
+	// Kubernetes node name (i.e. system:node:NodeName).
+	NodeMappings []NodeMapping
+
 	// AutoMappedAWSAccounts is a list of AWS accounts that are allowed without an explicit user/role mapping.
 	// IAM ARN from these accounts automatically maps to the Kubernetes username.
 	AutoMappedAWSAccounts []string
+
+	// DefaultEC2DescribeInstancesRoleARN is an optional AWS Resource Name for an IAM Role to be assumed
+	// before calling ec2:DescribeInstances to determine the private DNS of the calling kubelet (EC2 Instance).
+	// If nil, defaults to using the IAM Role attached to the instance where heptio-authenticator-aws is
+	// running.
+	DefaultEC2DescribeInstancesRoleARN string
 }


### PR DESCRIPTION
- kubelet reports itself as `system:node:<aws-private-dns>`
- modifies authenticator to be able to discover an ec2 instance's private dns
   and use it for the node name when the role is part of a NodeMapping
- allows a role to be specified in the config file to assume for the describe
   instances call, in case it is in a separate account.

Addresses [issues/57](https://github.com/heptio/authenticator/issues/57)