### PR TITLE
Add a new template variable {{EC2PrivateDNSName}} 

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -15,7 +15,34 @@
 
 [[projects]]
   name = "github.com/aws/aws-sdk-go"
-  packages = ["aws","aws/arn","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/credentials/stscreds","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/session","aws/signer/v4","internal/shareddefaults","private/protocol","private/protocol/query","private/protocol/query/queryutil","private/protocol/rest","private/protocol/xml/xmlutil","service/sts"]
+  packages = [
+    "aws",
+    "aws/arn",
+    "aws/awserr",
+    "aws/awsutil",
+    "aws/client",
+    "aws/client/metadata",
+    "aws/corehandlers",
+    "aws/credentials",
+    "aws/credentials/ec2rolecreds",
+    "aws/credentials/endpointcreds",
+    "aws/credentials/stscreds",
+    "aws/defaults",
+    "aws/ec2metadata",
+    "aws/endpoints",
+    "aws/request",
+    "aws/session",
+    "aws/signer/v4",
+    "internal/shareddefaults",
+    "private/protocol",
+    "private/protocol/ec2query",
+    "private/protocol/query",
+    "private/protocol/query/queryutil",
+    "private/protocol/rest",
+    "private/protocol/xml/xmlutil",
+    "service/ec2",
+    "service/sts"
+  ]
   revision = "885962fbd7bf49bf62db54f63fb89f75611677cf"
   version = "v1.12.8"
 
@@ -27,7 +54,10 @@
 
 [[projects]]
   name = "github.com/emicklei/go-restful"
-  packages = [".","log"]
+  packages = [
+    ".",
+    "log"
+  ]
   revision = "5741799b275a3c4a5a9623a993576d7545cf7b5c"
   version = "v2.4.0"
 
@@ -69,7 +99,10 @@
 
 [[projects]]
   name = "github.com/gogo/protobuf"
-  packages = ["proto","sortkeys"]
+  packages = [
+    "proto",
+    "sortkeys"
+  ]
   revision = "342cbe0a04158f6dcb03ca0079991a51a4248c02"
   version = "v0.5"
 
@@ -94,7 +127,17 @@
 [[projects]]
   branch = "master"
   name = "github.com/hashicorp/hcl"
-  packages = [".","hcl/ast","hcl/parser","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
+  packages = [
+    ".",
+    "hcl/ast",
+    "hcl/parser",
+    "hcl/scanner",
+    "hcl/strconv",
+    "hcl/token",
+    "json/parser",
+    "json/scanner",
+    "json/token"
+  ]
   revision = "42e33e2d55a0ff1d6263f738896ea8c13571a8d0"
 
 [[projects]]
@@ -117,7 +160,11 @@
 [[projects]]
   branch = "master"
   name = "github.com/mailru/easyjson"
-  packages = ["buffer","jlexer","jwriter"]
+  packages = [
+    "buffer",
+    "jlexer",
+    "jwriter"
+  ]
   revision = "2a92e673c9a6302dd05c3a691ae1f24aef46457d"
 
 [[projects]]
@@ -140,7 +187,10 @@
 
 [[projects]]
   name = "github.com/prometheus/client_golang"
-  packages = ["prometheus","prometheus/promhttp"]
+  packages = [
+    "prometheus",
+    "prometheus/promhttp"
+  ]
   revision = "967789050ba94deca04a5e84cce8ad472ce313c1"
   version = "v0.9.0-pre1"
 
@@ -153,13 +203,20 @@
 [[projects]]
   branch = "master"
   name = "github.com/prometheus/common"
-  packages = ["expfmt","internal/bitbucket.org/ww/goautoneg","model"]
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model"
+  ]
   revision = "2e54d0b93cba2fd133edc32211dcc32c06ef72ca"
 
 [[projects]]
   branch = "master"
   name = "github.com/prometheus/procfs"
-  packages = [".","xfs"]
+  packages = [
+    ".",
+    "xfs"
+  ]
   revision = "b15cd069a83443be3154b719d0cc9fe8117f09fb"
 
 [[projects]]
@@ -171,7 +228,10 @@
 [[projects]]
   branch = "master"
   name = "github.com/spf13/afero"
-  packages = [".","mem"]
+  packages = [
+    ".",
+    "mem"
+  ]
   revision = "e67d870304c4bca21331b02f414f970df13aa694"
 
 [[projects]]
@@ -213,19 +273,43 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["http2","http2/hpack","idna","lex/httplex"]
+  packages = [
+    "http2",
+    "http2/hpack",
+    "idna",
+    "lex/httplex"
+  ]
   revision = "a04bdaca5b32abe1c069418fb7088ae607de5bd0"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = ["unix","windows"]
+  packages = [
+    "unix",
+    "windows"
+  ]
   revision = "ebfc5b4631820b793c9010c87fd8fef0f39eb082"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/text"
-  packages = ["collate","collate/build","internal/colltab","internal/gen","internal/tag","internal/triegen","internal/ucd","language","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable","width"]
+  packages = [
+    "collate",
+    "collate/build",
+    "internal/colltab",
+    "internal/gen",
+    "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
+    "language",
+    "secure/bidirule",
+    "transform",
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable",
+    "width"
+  ]
   revision = "825fc78a2fd6fa0a5447e300189e3219e05e1f25"
 
 [[projects]]
@@ -249,7 +333,28 @@
 [[projects]]
   branch = "master"
   name = "k8s.io/apimachinery"
-  packages = ["pkg/api/resource","pkg/apis/meta/v1","pkg/conversion","pkg/conversion/queryparams","pkg/fields","pkg/labels","pkg/runtime","pkg/runtime/schema","pkg/selection","pkg/types","pkg/util/errors","pkg/util/intstr","pkg/util/net","pkg/util/runtime","pkg/util/sets","pkg/util/validation","pkg/util/validation/field","pkg/util/wait","pkg/watch","third_party/forked/golang/reflect"]
+  packages = [
+    "pkg/api/resource",
+    "pkg/apis/meta/v1",
+    "pkg/conversion",
+    "pkg/conversion/queryparams",
+    "pkg/fields",
+    "pkg/labels",
+    "pkg/runtime",
+    "pkg/runtime/schema",
+    "pkg/selection",
+    "pkg/types",
+    "pkg/util/errors",
+    "pkg/util/intstr",
+    "pkg/util/net",
+    "pkg/util/runtime",
+    "pkg/util/sets",
+    "pkg/util/validation",
+    "pkg/util/validation/field",
+    "pkg/util/wait",
+    "pkg/watch",
+    "third_party/forked/golang/reflect"
+  ]
   revision = "3b05bbfa0a45413bfa184edbf9af617e277962fb"
 
 [[projects]]
@@ -261,6 +366,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "526ede96d820faad72b528a225e12af05cc05acf4278793912ee516b7b873266"
+  inputs-digest = "ad2e44aaaa79261512e7cdc3458c850660aaebe7b25a47801bff69c6ca11e9d8"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -173,6 +173,9 @@ server:
   # output `path` where a generated webhook kubeconfig will be stored.
   generateKubeconfig: /etc/kubernetes/heptio-authenticator-aws.kubeconfig # (default)
 
+  # role to assume before querying EC2 API in order to discover metadata like EC2 private DNS Name
+  ec2DescribeInstancesRoleARN: arn:aws:iam::000000000000:role/DescribeInstancesRole
+
   # each mapRoles entry maps an IAM role to a username and set of groups
   # Each username and group can optionally contain template parameters:
   #  1) "{{AccountID}}" is the 12 digit AWS ID.
@@ -194,6 +197,17 @@ server:
     groups:
     - system:bootstrappers
     - aws:instances
+
+  # map nodes that should conform to the username "system:node:<private-DNS>".  This
+  # requires the authenticator to query the EC2 API in order to discover the private
+  # DNS of the EC2 instance originating the authentication request.  Optionally, you
+  # may specify a role that should be assumed before querying the EC2 API with the
+  # top level key "defaultEC2DescribeInstancesRoleARN".
+  - roleARN: arn:aws:iam::000000000000:role/KubernetesNode
+    username: system:node:{{EC2PrivateDNSName}}
+    groups:
+    - system:nodes
+    - system:bootstrappers
 
   # map federated users in my "KubernetesAdmin" role to users like
   # "admin:alice-example.com". The SessionName is an arbitrary role name
@@ -219,4 +233,5 @@ server:
   mapAccounts:
   - "012345678901"
   - "456789012345"
+
 ```

--- a/cmd/heptio-authenticator-aws/root.go
+++ b/cmd/heptio-authenticator-aws/root.go
@@ -75,11 +75,12 @@ func initConfig() {
 
 func getConfig() (config.Config, error) {
 	config := config.Config{
-		ClusterID:              viper.GetString("clusterID"),
-		LocalhostPort:          viper.GetInt("server.port"),
-		GenerateKubeconfigPath: viper.GetString("server.generateKubeconfig"),
-		KubeconfigPregenerated: viper.GetBool("server.kubeconfigPregenerated"),
-		StateDir:               viper.GetString("server.stateDir"),
+		ClusterID:                         viper.GetString("clusterID"),
+		ServerEC2DescribeInstancesRoleARN: viper.GetString("server.ec2DescribeInstancesRoleARN"),
+		LocalhostPort:                     viper.GetInt("server.port"),
+		GenerateKubeconfigPath:            viper.GetString("server.generateKubeconfig"),
+		KubeconfigPregenerated:            viper.GetBool("server.kubeconfigPregenerated"),
+		StateDir:                          viper.GetString("server.stateDir"),
 	}
 	if err := viper.UnmarshalKey("server.mapRoles", &config.RoleMappings); err != nil {
 		return config, fmt.Errorf("invalid server role mappings: %v", err)

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -92,4 +92,10 @@ type Config struct {
 	// AutoMappedAWSAccounts is a list of AWS accounts that are allowed without an explicit user/role mapping.
 	// IAM ARN from these accounts automatically maps to the Kubernetes username.
 	AutoMappedAWSAccounts []string
+
+	// ServerEC2DescribeInstancesRoleARN is an optional AWS Resource Name for an IAM Role to be assumed
+	// before calling ec2:DescribeInstances to determine the private DNS of the calling kubelet (EC2 Instance).
+	// If nil, defaults to using the IAM Role attached to the instance where heptio-authenticator-aws is
+	// running.
+	ServerEC2DescribeInstancesRoleARN string
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -57,6 +57,20 @@ func tokenReview(username, uid string, groups []string) authenticationv1beta1.To
 	}
 }
 
+type testEC2Provider struct {
+	name string
+}
+
+func (p *testEC2Provider) getPrivateDNSName(id string) (string, error) {
+	return p.name, nil
+}
+
+func newTestEC2Provider(name string) *testEC2Provider {
+	return &testEC2Provider{
+		name: name,
+	}
+}
+
 func setup(verifier token.Verifier) *handler {
 	return &handler{
 		verifier: verifier,
@@ -371,4 +385,40 @@ func TestAuthenticateVerifierAccountMappingForRole(t *testing.T) {
 	}
 	verifyAuthResult(t, resp, tokenReview("arn:aws:iam::0123456789012:role/Test", "heptio-authenticator-aws:0123456789012:Test", nil))
 	validateMetrics(t, validateOpts{success: 1})
+}
+
+func TestAuthenticateVerifierNodeMapping(t *testing.T) {
+	resp := httptest.NewRecorder()
+
+	data, err := json.Marshal(authenticationv1beta1.TokenReview{
+		Spec: authenticationv1beta1.TokenReviewSpec{
+			Token: "token",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Could not marshal in put data: %v", err)
+	}
+	req := httptest.NewRequest("POST", "http://k8s.io/authenticate", bytes.NewReader(data))
+	h := setup(&testVerifier{err: nil, identity: &token.Identity{
+		ARN:          "arn:aws:iam::0123456789012:role/TestNodeRole",
+		CanonicalARN: "arn:aws:iam::0123456789012:role/TestNodeRole",
+		AccountID:    "0123456789012",
+		UserID:       "TestNodeRole",
+		SessionName:  "i-0c6f21bf1f24f9708",
+	}})
+	defer cleanup(h.metrics)
+	h.ec2Provider = newTestEC2Provider("ip-172-31-27-14")
+	h.lowercaseRoleMap = make(map[string]config.RoleMapping)
+	h.lowercaseRoleMap["arn:aws:iam::0123456789012:role/testnoderole"] = config.RoleMapping{
+		RoleARN:  "arn:aws:iam::0123456789012:role/TestNodeRole",
+		Username: "system:node:{{EC2PrivateDNSName}}",
+		Groups:   []string{"system:nodes", "system:bootstrappers"},
+	}
+	h.authenticateEndpoint(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Errorf("Expected status code %d, was %d", http.StatusOK, resp.Code)
+	}
+	verifyAuthResult(t, resp, tokenReview("system:node:ip-172-31-27-14", "heptio-authenticator-aws:0123456789012:TestNodeRole", []string{"system:nodes", "system:bootstrappers"}))
+	validateMetrics(t, validateOpts{success: 1})
+
 }


### PR DESCRIPTION
- kubelet reports itself as `system:node:<aws-private-dns>`
- modifies authenticator to be able to discover an ec2 instance's private dns
  and use it for the node name when {{EC2PrivateDNSName}} is used in the
  template username
- allows a role to be specified in the config file to assume for the describe
  instances call, in case it is in a separate account.

Fixes: https://github.com/heptio/authenticator/issues/57
Alternative to: https://github.com/heptio/authenticator/pull/61

Signed-off-by: Nick Turner <nic@amazon.com>