### PR TITLE
Add OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- mattmoyer
+- nckturner
+- mattlandis
+reviewers:
+- mattmoyer
+- nckturner
+- mattlandis


### PR DESCRIPTION
If heptio/authenticator is to be a SIG-AWS subproject, we need an OWNERS file.

Signed-off-by: Nick Turner <nic@amazon.com>