### PR TITLE
Pull the response body so we can log it if there's an error

### DIFF
--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -212,13 +212,13 @@ func Verify(token string, serverID string) (*Identity, error) {
 	}
 	defer response.Body.Close()
 
-	if response.StatusCode != 200 {
-		return nil, fmt.Errorf("error from AWS (expected 200, got %d)", response.StatusCode)
-	}
-
 	responseBody, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error reading HTTP result: %v", err)
+	}
+
+	if response.StatusCode != 200 {
+		return nil, fmt.Errorf("error from AWS (expected 200, got %d), %s", response.StatusCode, responseBody)
 	}
 
 	var callerIdentity getCallerIdentityWrapper


### PR DESCRIPTION
Change when the response body is read so that we can log it in the output if there's an error.

Makes issue diagnosis easier, for instance, if you have a mistaken cluster ID